### PR TITLE
Add Cognito access

### DIFF
--- a/elasticsearch.tf
+++ b/elasticsearch.tf
@@ -54,10 +54,11 @@ resource "aws_elasticsearch_domain" "es" {
 
   cognito_options {
     enabled = true
-    # This stuff was set up manually
-    identity_pool_id = "us-east-1:33b8b144-e2e5-43c7-853d-0f3760068edc"
-    role_arn         = "arn:aws:iam::344440683180:role/service-role/CognitoAccessForAmazonES"
-    user_pool_id     = "us-east-1_dXlTwH4Y7"
+    # This stuff was set up manually.  See
+    # https://github.com/cisagov/dmarc-import-terraform/issues/10.
+    identity_pool_id = var.cognito_identity_pool_id
+    role_arn         = var.cognito_role_arn
+    user_pool_id     = var.cognito_user_pool_id
   }
 
   log_publishing_options {

--- a/elasticsearch.tf
+++ b/elasticsearch.tf
@@ -1,6 +1,6 @@
 # The CloudWatch log group where application logs will be written
 resource "aws_cloudwatch_log_group" "es_logs" {
-  name              = "/aws/aes/domains/${var.elasticsearch_domain_name}"
+  name              = "/aws/aes/domains/${var.elasticsearch_domain_name}/application-logs"
   retention_in_days = 30
 
   tags = var.tags

--- a/elasticsearch.tf
+++ b/elasticsearch.tf
@@ -52,6 +52,14 @@ resource "aws_elasticsearch_domain" "es" {
     enabled = true
   }
 
+  cognito_options {
+    enabled = true
+    # This stuff was set up manually
+    identity_pool_id = "us-east-1:33b8b144-e2e5-43c7-853d-0f3760068edc"
+    role_arn         = "arn:aws:iam::344440683180:role/service-role/CognitoAccessForAmazonES"
+    user_pool_id     = "us-east-1_dXlTwH4Y7"
+  }
+
   log_publishing_options {
     cloudwatch_log_group_arn = aws_cloudwatch_log_group.es_logs.arn
     log_type                 = "ES_APPLICATION_LOGS"

--- a/production.tfvars
+++ b/production.tfvars
@@ -20,6 +20,12 @@ elasticsearch_type = "report"
 
 elasticsearch_domain_name = "dmarc-import-elasticsearch"
 
+cognito_identity_pool_id = "us-east-1:33b8b144-e2e5-43c7-853d-0f3760068edc"
+
+cognito_user_pool_id = "us-east-1_dXlTwH4Y7"
+
+cognito_role_arn = "arn:aws:iam::344440683180:role/service-role/CognitoAccessForAmazonES"
+
 tags = {
   Team = "NCATS OIS - Development"
   Application = "dmarc-import"

--- a/variables.tf
+++ b/variables.tf
@@ -48,6 +48,21 @@ variable "elasticsearch_domain_name" {
   description = "The domain name of the Elasticsearch instance"
 }
 
+variable "cognito_identity_pool_id" {
+  type        = string
+  description = "The ID of the Cognito identity pool to use for Kibana access."
+}
+
+variable "cognito_user_pool_id" {
+  type        = string
+  description = "The ID of the Cognito user pool to use for Kibana access."
+}
+
+variable "cognito_role_arn" {
+  type        = string
+  description = "The ARN of the role that grants Cognito access for Elasticsearch.  If you are using the AWS-provided role for this purpose, then the ARN will look like arn:aws:iam::<account-id>:role/service-role/CognitoAccessForAmazonES."
+}
+
 variable "tags" {
   type        = map(string)
   default     = {}


### PR DESCRIPTION
I did this manually some weeks ago, but when I redeployed to reanimate the DMARC-import Lambda function I needed to add some Cognito fu here in order to avoid clobbering what was done manually.

The identity and user pools are still created manually.  This should be remedied in a future PR.  I created #10 for this.