### PR TITLE
Enable Cognito access to Elasticsearch database

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,23 @@ No modules.
 | [aws_cloudwatch_log_group.es_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_resource_policy.es_cloudwatch_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_resource_policy) | resource |
+| [aws_cognito_identity_pool.dmarc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_identity_pool) | resource |
+| [aws_cognito_identity_pool_roles_attachment.dmarc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_identity_pool_roles_attachment) | resource |
+| [aws_cognito_managed_user_pool_client.dmarc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_managed_user_pool_client) | resource |
+| [aws_cognito_user.dmarc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user) | resource |
+| [aws_cognito_user_pool.dmarc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool) | resource |
+| [aws_cognito_user_pool_domain.dmarc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool_domain) | resource |
 | [aws_elasticsearch_domain.es](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticsearch_domain) | resource |
+| [aws_iam_role.cognito_authenticated](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.opensearch_cognito](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.cloudwatch_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.cognito_authenticated](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.es_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.lambda_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.s3_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.sqs_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.opensearch_cognito](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_function.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_permission.allow_cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_s3_bucket.permanent](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
@@ -91,9 +101,13 @@ No modules.
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cloudwatch_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cognito_authenticated](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cognito_authenticated_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.es_cloudwatch_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.es_cognito_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.es_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.lambda_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.opensearch_cognito_trust](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_sqs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ses_permanent_s3_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -105,12 +119,19 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | aws\_region | The AWS region to deploy into (e.g. us-east-1). | `string` | `"us-east-1"` | no |
+| cognito\_authenticated\_role\_name | The name of the IAM role that grants authenticated access to the Elasticsearch database. | `string` | `"dmarc-import-authenticated"` | no |
+| cognito\_identity\_pool\_name | The name of the Cognito identity pool to use for access to the Elasticsearch database. | `string` | `"dmarc-import"` | no |
+| cognito\_user\_pool\_client\_name | The name of the Cognito user pool client to use for access to the Elasticsearch database. | `string` | `"dmarc-import"` | no |
+| cognito\_user\_pool\_domain | The domain to use for the Cognito endpoint. For custom domains, this is the fully-qualified domain name, such as auth.example.com. For Amazon Cognito prefix domains, this is the prefix alone, such as auth. | `string` | `"dmarc-import"` | no |
+| cognito\_user\_pool\_name | The name of the Cognito user pool to use for access to the Elasticsearch database. | `string` | `"dmarc-import"` | no |
+| cognito\_usernames | A map whose keys are the usernames of each Cognito user and whose values are a map containing supported user attributes.  The only currently-supported attribute is "email" (string).  Example: `{ "firstname1.lastname1" = { "email" = "firstname1.lastname1@foo.gov" }, "firstname2.lastname2" = { "email" = "firstname2.lastname2@foo.gov" } }` | `map(object({ email = string }))` | `{}` | no |
 | elasticsearch\_domain\_name | The domain name of the Elasticsearch instance. | `string` | n/a | yes |
 | elasticsearch\_index | The Elasticsearch index to which to write DMARC aggregate report data. | `string` | n/a | yes |
 | elasticsearch\_type | The Elasticsearch type corresponding to a DMARC aggregate report. | `string` | n/a | yes |
 | emails | A list of the email addresses at which DMARC aggregate reports are being received. | `list(string)` | n/a | yes |
 | lambda\_function\_name | The name to use for the Lambda function. | `string` | n/a | yes |
 | lambda\_function\_zip\_file | The location of the zip file for the Lambda function. | `string` | n/a | yes |
+| opensearch\_service\_role\_for\_auth\_name | The name of the IAM role that gives Amazon OpenSearch Service permissions to configure the Amazon Cognito user and identity pools and use them for OpenSearch Dashboards/Kibana authentication. | `string` | `"opensearch-service-cognito-access"` | no |
 | permanent\_bucket\_name | The name of the S3 bucket where the DMARC aggregate report emails are stored permanently. | `string` | n/a | yes |
 | queue\_name | The name of the SQS queue where events will be sent as DMARC aggregate reports are received. | `string` | n/a | yes |
 | rule\_set\_name | The name of the SES rule set that processes DMARC aggregate reports. | `string` | n/a | yes |

--- a/cognito.tf
+++ b/cognito.tf
@@ -128,8 +128,8 @@ data "aws_iam_policy_document" "cognito_authenticated_role_policy" {
 
 resource "aws_iam_role_policy" "cognito_authenticated" {
   name   = "${var.cognito_authenticated_role_name}_policy"
-  role   = aws_iam_role.cognito_authenticated.id
   policy = data.aws_iam_policy_document.cognito_authenticated_role_policy.json
+  role   = aws_iam_role.cognito_authenticated.id
 }
 
 # Attach the Cognito authenticated role to the Cognito identity pool
@@ -137,8 +137,8 @@ resource "aws_cognito_identity_pool_roles_attachment" "dmarc" {
   identity_pool_id = aws_cognito_identity_pool.dmarc.id
 
   role_mapping {
-    identity_provider         = "cognito-idp.${var.aws_region}.amazonaws.com/${aws_cognito_user_pool.dmarc.id}:${aws_cognito_managed_user_pool_client.dmarc.id}"
     ambiguous_role_resolution = "AuthenticatedRole"
+    identity_provider         = "cognito-idp.${var.aws_region}.amazonaws.com/${aws_cognito_user_pool.dmarc.id}:${aws_cognito_managed_user_pool_client.dmarc.id}"
     type                      = "Rules"
 
     mapping_rule {

--- a/cognito.tf
+++ b/cognito.tf
@@ -49,6 +49,10 @@ resource "aws_cognito_managed_user_pool_client" "dmarc" {
   name_prefix  = "AmazonOpenSearchService-${var.cognito_user_pool_name}"
   user_pool_id = aws_cognito_user_pool.dmarc.id
 
+  # Since our Cognito user pool client is automatically created by Elasticsearch
+  # (OpenSearch), we add a manual dependency here to ensure that the
+  # Elasticsearch (OpenSearch) domain (and the user pool client) is created
+  # before we create this aws_cognito_managed_user_pool_client resource.
   depends_on = [
     aws_elasticsearch_domain.es,
   ]

--- a/cognito.tf
+++ b/cognito.tf
@@ -48,3 +48,125 @@ resource "aws_cognito_user_pool_domain" "dmarc" {
   domain       = var.cognito_user_pool_domain
   user_pool_id = aws_cognito_user_pool.dmarc.id
 }
+
+# The Cognito identity pool
+resource "aws_cognito_identity_pool" "dmarc" {
+  allow_unauthenticated_identities = false
+  identity_pool_name               = var.cognito_identity_pool_name
+
+  # We don't need to specify the cognito_identity_providers here since the
+  # provider is automatically configured by AWS.  This is why we must include
+  # the lifecycle block below to ignore changes to cognito_identity_providers.
+  #
+  # https://docs.aws.amazon.com/opensearch-service/latest/developerguide/cognito-auth.html
+  # states: "You don't need to add external identity providers to the identity
+  # pool. When you configure OpenSearch Service to use Amazon Cognito
+  # authentication, it configures the identity pool to use the user pool that
+  # you just created."
+  lifecycle {
+    ignore_changes = [cognito_identity_providers]
+  }
+}
+
+# The Cognito identity pool role and related policies
+data "aws_iam_policy_document" "cognito_authenticated" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Federated"
+      identifiers = ["cognito-identity.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "cognito-identity.amazonaws.com:aud"
+      values   = [aws_cognito_identity_pool.dmarc.id]
+    }
+
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "cognito-identity.amazonaws.com:amr"
+      values   = ["authenticated"]
+    }
+  }
+}
+
+resource "aws_iam_role" "cognito_authenticated" {
+  name               = var.cognito_authenticated_role_name
+  assume_role_policy = data.aws_iam_policy_document.cognito_authenticated.json
+}
+
+data "aws_iam_policy_document" "cognito_authenticated_role_policy" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "cognito-identity:GetCredentialsForIdentity",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "cognito_authenticated" {
+  name   = "${var.cognito_authenticated_role_name}_policy"
+  role   = aws_iam_role.cognito_authenticated.id
+  policy = data.aws_iam_policy_document.cognito_authenticated_role_policy.json
+}
+
+# Attach the Cognito authenticated role to the Cognito identity pool
+resource "aws_cognito_identity_pool_roles_attachment" "dmarc" {
+  identity_pool_id = aws_cognito_identity_pool.dmarc.id
+
+  role_mapping {
+    identity_provider         = "cognito-idp.${var.aws_region}.amazonaws.com/${aws_cognito_user_pool.dmarc.id}:${aws_cognito_managed_user_pool_client.dmarc.id}"
+    ambiguous_role_resolution = "AuthenticatedRole"
+    type                      = "Rules"
+
+    mapping_rule {
+      claim      = "isAdmin"
+      match_type = "Equals"
+      role_arn   = aws_iam_role.cognito_authenticated.arn
+      value      = "yes"
+    }
+  }
+
+  roles = {
+    "authenticated" = aws_iam_role.cognito_authenticated.arn
+  }
+}
+
+# Trust policy for the IAM role that gives Amazon OpenSearch Service permissions
+# to configure the Amazon Cognito user and identity pools and use them for
+# OpenSearch Dashboards/Kibana authentication
+data "aws_iam_policy_document" "opensearch_cognito_trust" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    effect = "Allow"
+
+    principals {
+      identifiers = ["es.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+# IAM role that gives Amazon OpenSearch Service permissions to configure the
+# Amazon Cognito user and identity pools and use them for OpenSearch
+# Dashboards/Kibana authentication
+resource "aws_iam_role" "opensearch_cognito" {
+  assume_role_policy = data.aws_iam_policy_document.opensearch_cognito_trust.json
+  name               = var.opensearch_service_role_for_auth_name
+}
+
+# IAM policy attachment that gives Amazon OpenSearch Service permissions to
+# configure the Amazon Cognito user and identity pools and use them for
+# OpenSearch Dashboards/Kibana authentication
+resource "aws_iam_role_policy_attachment" "opensearch_cognito" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonOpenSearchServiceCognitoAccess"
+  role       = aws_iam_role.opensearch_cognito.name
+}

--- a/cognito.tf
+++ b/cognito.tf
@@ -1,5 +1,16 @@
 # Cognito resources used by the Elasticsearch domain
 
+# Cognito users
+resource "aws_cognito_user" "dmarc" {
+  for_each = { for k, v in var.cognito_usernames : k => v }
+
+  user_pool_id = aws_cognito_user_pool.dmarc.id
+  username     = each.key
+  attributes = {
+    email = each.value["email"]
+  }
+}
+
 # The Cognito user pool
 resource "aws_cognito_user_pool" "dmarc" {
   account_recovery_setting {

--- a/cognito.tf
+++ b/cognito.tf
@@ -1,0 +1,50 @@
+# Cognito resources used by the Elasticsearch domain
+
+# The Cognito user pool
+resource "aws_cognito_user_pool" "dmarc" {
+  account_recovery_setting {
+    recovery_mechanism {
+      name     = "verified_email"
+      priority = 1
+    }
+  }
+
+  admin_create_user_config {
+    allow_admin_create_user_only = true
+  }
+
+  auto_verified_attributes = [
+    "email",
+  ]
+
+  mfa_configuration = "ON"
+  name              = var.cognito_user_pool_name
+  software_token_mfa_configuration {
+    enabled = true
+  }
+  user_attribute_update_settings {
+    attributes_require_verification_before_update = [
+      "email",
+    ]
+  }
+}
+
+# The managed Cognito user pool client for the Elasticsearch endpoint. This
+# resource is used to manage the Cognito user pool client that is automatically
+# created by Elasticsearch (OpenSearch) when Cognito authentication is enabled.
+# Thanks to this comment for pointing me in the right direction:
+# https://github.com/hashicorp/terraform-provider-aws/issues/5557#issuecomment-1015731466
+resource "aws_cognito_managed_user_pool_client" "dmarc" {
+  name_prefix  = "AmazonOpenSearchService-${var.cognito_user_pool_name}"
+  user_pool_id = aws_cognito_user_pool.dmarc.id
+
+  depends_on = [
+    aws_elasticsearch_domain.es,
+  ]
+}
+
+# The Cognito user pool domain
+resource "aws_cognito_user_pool_domain" "dmarc" {
+  domain       = var.cognito_user_pool_domain
+  user_pool_id = aws_cognito_user_pool.dmarc.id
+}

--- a/cognito.tf
+++ b/cognito.tf
@@ -88,12 +88,12 @@ data "aws_iam_policy_document" "cognito_authenticated" {
   statement {
     effect = "Allow"
 
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
     principals {
       type        = "Federated"
       identifiers = ["cognito-identity.amazonaws.com"]
     }
-
-    actions = ["sts:AssumeRoleWithWebIdentity"]
 
     condition {
       test     = "StringEquals"
@@ -159,9 +159,9 @@ resource "aws_cognito_identity_pool_roles_attachment" "dmarc" {
 # OpenSearch Dashboards/Kibana authentication
 data "aws_iam_policy_document" "opensearch_cognito_trust" {
   statement {
-    actions = ["sts:AssumeRole"]
-
     effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
 
     principals {
       identifiers = ["es.amazonaws.com"]

--- a/elasticsearch.tf
+++ b/elasticsearch.tf
@@ -31,10 +31,41 @@ resource "aws_cloudwatch_log_resource_policy" "es_cloudwatch_policy" {
   policy_name     = "dmarc-import-es-cloudwatch-policy"
 }
 
+# Policy document that allows authenticated Cognito users access to the
+# Elasticsearch domain
+data "aws_iam_policy_document" "es_cognito_auth" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "es:*",
+    ]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        aws_iam_role.cognito_authenticated.arn,
+      ]
+    }
+
+    resources = [
+      "arn:aws:es:${var.aws_region}:*:domain/${var.elasticsearch_domain_name}/*",
+    ]
+  }
+}
+
 # The Elasticsearch domain
 resource "aws_elasticsearch_domain" "es" {
+  access_policies       = data.aws_iam_policy_document.es_cognito_auth.json
   domain_name           = var.elasticsearch_domain_name
   elasticsearch_version = "OpenSearch_1.3"
+
+  cognito_options {
+    enabled          = true
+    identity_pool_id = aws_cognito_identity_pool.dmarc.id
+    role_arn         = aws_iam_role.opensearch_cognito.arn
+    user_pool_id     = aws_cognito_user_pool.dmarc.id
+  }
 
   cluster_config {
     instance_type  = "m6g.large.elasticsearch"

--- a/elasticsearch.tf
+++ b/elasticsearch.tf
@@ -55,15 +55,6 @@ resource "aws_elasticsearch_domain" "es" {
     enabled = true
   }
 
-  # cognito_options {
-  #   enabled = true
-  #   # This stuff was set up manually.  See
-  #   # https://github.com/cisagov/dmarc-import-terraform/issues/10.
-  #   identity_pool_id = var.cognito_identity_pool_id
-  #   role_arn         = var.cognito_role_arn
-  #   user_pool_id     = var.cognito_user_pool_id
-  # }
-
   log_publishing_options {
     cloudwatch_log_group_arn = aws_cloudwatch_log_group.es_logs.arn
     log_type                 = "ES_APPLICATION_LOGS"

--- a/elasticsearch.tf
+++ b/elasticsearch.tf
@@ -60,13 +60,6 @@ resource "aws_elasticsearch_domain" "es" {
   domain_name           = var.elasticsearch_domain_name
   elasticsearch_version = "OpenSearch_1.3"
 
-  cognito_options {
-    enabled          = true
-    identity_pool_id = aws_cognito_identity_pool.dmarc.id
-    role_arn         = aws_iam_role.opensearch_cognito.arn
-    user_pool_id     = aws_cognito_user_pool.dmarc.id
-  }
-
   cluster_config {
     instance_type  = "m6g.large.elasticsearch"
     instance_count = 3
@@ -74,6 +67,13 @@ resource "aws_elasticsearch_domain" "es" {
       availability_zone_count = 3
     }
     zone_awareness_enabled = true
+  }
+
+  cognito_options {
+    enabled          = true
+    identity_pool_id = aws_cognito_identity_pool.dmarc.id
+    role_arn         = aws_iam_role.opensearch_cognito.arn
+    user_pool_id     = aws_cognito_user_pool.dmarc.id
   }
 
   ebs_options {

--- a/variables.tf
+++ b/variables.tf
@@ -4,21 +4,6 @@
 # You must provide a value for each of these parameters.
 # ------------------------------------------------------------------------------
 
-# variable "cognito_identity_pool_id" {
-#   type        = string
-#   description = "The ID of the Cognito identity pool to use for Kibana access."
-# }
-
-# variable "cognito_role_arn" {
-#   type        = string
-#   description = "The ARN of the role that grants Cognito access for Elasticsearch.  If you are using the AWS-provided role for this purpose, then the ARN will look like arn:aws:iam::<account-id>:role/service-role/CognitoAccessForAmazonES."
-# }
-
-# variable "cognito_user_pool_id" {
-#   type        = string
-#   description = "The ID of the Cognito user pool to use for Kibana access."
-# }
-
 variable "elasticsearch_domain_name" {
   type        = string
   description = "The domain name of the Elasticsearch instance."

--- a/variables.tf
+++ b/variables.tf
@@ -65,3 +65,45 @@ variable "aws_region" {
   description = "The AWS region to deploy into (e.g. us-east-1)."
   default     = "us-east-1"
 }
+
+variable "cognito_authenticated_role_name" {
+  default     = "dmarc-import-authenticated"
+  description = "The name of the IAM role that grants authenticated access to the Elasticsearch database."
+  type        = string
+}
+
+variable "cognito_identity_pool_name" {
+  default     = "dmarc-import"
+  description = "The name of the Cognito identity pool to use for access to the Elasticsearch database."
+  type        = string
+}
+
+variable "cognito_user_pool_client_name" {
+  default     = "dmarc-import"
+  description = "The name of the Cognito user pool client to use for access to the Elasticsearch database."
+  type        = string
+}
+
+variable "cognito_user_pool_domain" {
+  default     = "dmarc-import"
+  description = "The domain to use for the Cognito endpoint. For custom domains, this is the fully-qualified domain name, such as auth.example.com. For Amazon Cognito prefix domains, this is the prefix alone, such as auth."
+  type        = string
+}
+
+variable "cognito_user_pool_name" {
+  default     = "dmarc-import"
+  description = "The name of the Cognito user pool to use for access to the Elasticsearch database."
+  type        = string
+}
+
+variable "cognito_usernames" {
+  default     = {}
+  description = "A map whose keys are the usernames of each Cognito user and whose values are a map containing supported user attributes.  The only currently-supported attribute is \"email\" (string).  Example: { \"firstname1.lastname1\" = { \"email\" = \"firstname1.lastname1@foo.gov\" }, \"firstname2.lastname2\" = { \"email\" = \"firstname2.lastname2@foo.gov\" } }"
+  type        = map(object({ email = string }))
+}
+
+variable "opensearch_service_role_for_auth_name" {
+  default     = "opensearch-service-cognito-access"
+  description = "The name of the IAM role that gives Amazon OpenSearch Service permissions to configure the Amazon Cognito user and identity pools and use them for OpenSearch Dashboards/Kibana authentication."
+  type        = string
+}


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR defines the Cognito access to Elasticsearch via Terraform.  It also enables creation/deletion of Cognito users with Terraform.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Cognito resources and access were previously configured manually, so this is an improvement.

I marked this PR as `blocked` since it should be merged in conjunction with https://github.com/cisagov/cool-dns-dmarc-import/pull/11.

Resolves #10.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested this by targeting Terraform applies in Production (using [`cisagov/cool-dns-dmarc-import`](https://github.com/cisagov/cool-dns-dmarc-import)) until everything applied correctly.  After that, I created and deleted test users until I was satisfied that everything was working as intended.  

I confirmed that my Cognito user was able to sign up using the temporary password that is generated, create an MFA token, login to the ~Elasticsearch~ Open Search dashboard, and query for some data.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
